### PR TITLE
use command -v instead of which

### DIFF
--- a/EDTA.pl
+++ b/EDTA.pl
@@ -271,26 +271,26 @@ die "The script density_table.py is not found in $density_table!\n" unless -s $d
 die "The script density_plot.R is not found in $density_plot!\n" unless -s $density_plot;
 
 # GenomeTools
-chomp ($genometools=`which gt 2>/dev/null`) if $genometools eq '';
+chomp ($genometools=`command -v gt 2>/dev/null`) if $genometools eq '';
 $genometools =~ s/\s+$//;
 $genometools = dirname($genometools) unless -d $genometools;
 $genometools="$genometools/" if $genometools ne '' and $genometools !~ /\/$/;
 die "Error: gt is not found in the genometools path $genometools!\n" unless -X "${genometools}gt";
 # AnnoSINE
-chomp ($annosine=`which AnnoSINE_v2 2>/dev/null`) if $annosine eq '';
+chomp ($annosine=`command -v AnnoSINE_v2 2>/dev/null`) if $annosine eq '';
 $annosine =~ s/\s+$//;
 $annosine = dirname($annosine) unless -d $annosine;
 $annosine="$annosine/" if $annosine ne '' and $annosine !~ /\/$/;
 die "Error: AnnoSINE is not found in the AnnoSINE path $annosine!\n" unless (-X "${annosine}AnnoSINE_v2");
 # LTR_retriever
-chomp ($LTR_retriever=`which LTR_retriever 2>/dev/null`) if $LTR_retriever eq '';
+chomp ($LTR_retriever=`command -v LTR_retriever 2>/dev/null`) if $LTR_retriever eq '';
 $LTR_retriever =~ s/\s+$//;
 $LTR_retriever = dirname($LTR_retriever) unless -d $LTR_retriever;
 $LTR_retriever="$LTR_retriever/" if $LTR_retriever ne '' and $LTR_retriever !~ /\/$/;
 die "Error: LTR_retriever is not found in the LTR_retriever path $LTR_retriever!\n" unless -X "${LTR_retriever}LTR_retriever";
 # RepeatMasker
 my $rand=int(rand(1000000));
-chomp ($repeatmasker=`which RepeatMasker 2>/dev/null`) if $repeatmasker eq '';
+chomp ($repeatmasker=`command -v RepeatMasker 2>/dev/null`) if $repeatmasker eq '';
 $repeatmasker =~ s/\s+$//;
 $repeatmasker = dirname($repeatmasker) unless -d $repeatmasker;
 $repeatmasker="$repeatmasker/" if $repeatmasker ne '' and $repeatmasker !~ /\/$/;
@@ -300,13 +300,13 @@ my $RM_test=`${repeatmasker}RepeatMasker -e ncbi -q -pa 1 -no_is -nolow dummy060
 die "Error: The RMblast engine is not installed in RepeatMasker!\n" unless $RM_test=~s/done//gi;
 `rm dummy060817.fa.$rand* 2>/dev/null`;
 # RepeatModeler
-chomp ($repeatmodeler=`which RepeatModeler 2>/dev/null`) if $repeatmodeler eq '';
+chomp ($repeatmodeler=`command -v RepeatModeler 2>/dev/null`) if $repeatmodeler eq '';
 $repeatmodeler =~ s/\s+$//;
 $repeatmodeler = dirname($repeatmodeler) unless -d $repeatmodeler;
 $repeatmodeler="$repeatmodeler/" if $repeatmodeler ne '' and $repeatmodeler !~ /\/$/;
 die "Error: RepeatModeler is not found in the RepeatModeler path $repeatmodeler!\n" unless -X "${repeatmodeler}RepeatModeler";
 # makeblastdb, blastn, blastx
-chomp ($blastplus=`which makeblastdb 2>/dev/null`) if $blastplus eq '';
+chomp ($blastplus=`command -v makeblastdb 2>/dev/null`) if $blastplus eq '';
 $blastplus =~ s/\s+$//;
 $blastplus = dirname($blastplus) unless -d $blastplus;
 $blastplus="$blastplus/" if $blastplus ne '' and $blastplus !~ /\/$/;
@@ -314,24 +314,24 @@ die "Error: makeblastdb is not found in the BLAST+ path $blastplus!\n" unless -X
 die "Error: blastn is not found in the BLAST+ path $blastplus!\n" unless -X "${blastplus}blastn";
 die "Error: blastx is not found in the BLAST+ path $blastplus!\n" unless -X "${blastplus}blastx";
 # TEsorter
-chomp ($TEsorter=`which TEsorter 2>/dev/null`) if $TEsorter eq '';
+chomp ($TEsorter=`command -v TEsorter 2>/dev/null`) if $TEsorter eq '';
 $TEsorter =~ s/\s+$//;
 $TEsorter = dirname($TEsorter) unless -d $TEsorter;
 $TEsorter="$TEsorter/" if $TEsorter ne '' and $TEsorter !~ /\/$/;
 die "Error: TEsorter is not found in the TEsorter path $TEsorter!\n" unless -X "${TEsorter}TEsorter";
 # mdust
-chomp ($mdust=`which mdust 2>/dev/null`) if $mdust eq '';
+chomp ($mdust=`command -v mdust 2>/dev/null`) if $mdust eq '';
 $mdust =~ s/\s+$//;
 $mdust = dirname($mdust) unless -d $mdust;
 $mdust = "$mdust/" if $mdust ne '' and $mdust !~ /\/$/;
 die "Error: mdust is not found in the mdust path $mdust!\n" unless -X "${mdust}mdust";
 # trf
-chomp ($trf=`which trf 2>/dev/null`) if $trf eq '';
+chomp ($trf=`command -v trf 2>/dev/null`) if $trf eq '';
 $trf=~s/\n$//;
 `$trf 2>/dev/null`;
 die "Error: Tandem Repeat Finder is not found in the TRF path $trf!\n" if $?==32256;
 # GRF
-chomp ($GRF = `which grf-main 2>/dev/null`) if $GRF eq '';
+chomp ($GRF = `command -v grf-main 2>/dev/null`) if $GRF eq '';
 $GRF =~ s/\n$//;
 `$GRF 2>/dev/null`;
 die "Error: The Generic Repeat Finder (GRF) is not found in the GRF path: $GRF\n" if $?==32256;

--- a/EDTA_raw.pl
+++ b/EDTA_raw.pl
@@ -171,14 +171,14 @@ die "The script bed2gff.pl is not found in $bed2gff!\n" unless -s $bed2gff;
 die "The script make_bed_with_intact.pl is not found in $make_bed!\n" unless -s $make_bed;
 
 # GenomeTools
-chomp ($genometools=`which gt 2>/dev/null`) if $genometools eq '';
+chomp ($genometools=`command -v gt 2>/dev/null`) if $genometools eq '';
 $genometools =~ s/\s+$//;
 $genometools = dirname($genometools) unless -d $genometools;
 $genometools="$genometools/" if $genometools ne '' and $genometools !~ /\/$/;
 die "Error: gt is not found in the genometools path $genometools!\n" unless -X "${genometools}gt";
 # RepeatMasker
 my $rand=int(rand(1000000));
-chomp ($repeatmasker=`which RepeatMasker 2>/dev/null`) if $repeatmasker eq '';
+chomp ($repeatmasker=`command -v RepeatMasker 2>/dev/null`) if $repeatmasker eq '';
 $repeatmasker =~ s/\s+$//;
 $repeatmasker = dirname($repeatmasker) unless -d $repeatmasker;
 $repeatmasker="$repeatmasker/" if $repeatmasker ne '' and $repeatmasker !~ /\/$/;
@@ -188,49 +188,49 @@ my $RM_test=`${repeatmasker}RepeatMasker -e ncbi -q -pa 1 -no_is -nolow dummy060
 die "Error: The RMblast engine is not installed in RepeatMasker!\n" unless $RM_test=~s/done//gi;
 `rm dummy060817.fa.$rand*`;
 # RepeatModeler
-chomp ($repeatmodeler=`which RepeatModeler 2>/dev/null`) if $repeatmodeler eq '';
+chomp ($repeatmodeler=`command -v RepeatModeler 2>/dev/null`) if $repeatmodeler eq '';
 $repeatmodeler =~ s/\s+$//;
 $repeatmodeler = dirname($repeatmodeler) unless -d $repeatmodeler;
 $repeatmodeler="$repeatmodeler/" if $repeatmodeler ne '' and $repeatmodeler !~ /\/$/;
 die "Error: RepeatModeler is not found in the RepeatModeler path $repeatmodeler!\n" unless -X "${repeatmodeler}RepeatModeler";
 # AnnoSINE
-chomp ($annosine=`which AnnoSINE_v2 2>/dev/null`) if $annosine eq '';
+chomp ($annosine=`command -v AnnoSINE_v2 2>/dev/null`) if $annosine eq '';
 $annosine =~ s/\s+$//;
 $annosine = dirname($annosine) unless -d $annosine;
 $annosine="$annosine/" if $annosine ne '' and $annosine !~ /\/$/;
 die "Error: AnnoSINE is not found in the AnnoSINE path $annosine!\n" unless (-X "${annosine}AnnoSINE_v2");
 # LTR_retriever
-chomp ($LTR_retriever=`which LTR_retriever 2>/dev/null`) if $LTR_retriever eq '';
+chomp ($LTR_retriever=`command -v LTR_retriever 2>/dev/null`) if $LTR_retriever eq '';
 $LTR_retriever =~ s/\s+$//;
 $LTR_retriever = dirname($LTR_retriever) unless -d $LTR_retriever;
 $LTR_retriever="$LTR_retriever/" if $LTR_retriever ne '' and $LTR_retriever !~ /\/$/;
 die "Error: LTR_retriever is not found in the LTR_retriever path $LTR_retriever!\n" unless -X "${LTR_retriever}LTR_retriever";
 # TEsorter
-chomp ($TEsorter=`which TEsorter 2>/dev/null`) if $TEsorter eq '';
+chomp ($TEsorter=`command -v TEsorter 2>/dev/null`) if $TEsorter eq '';
 $TEsorter =~ s/\s+$//;
 $TEsorter = dirname($TEsorter) unless -d $TEsorter;
 $TEsorter="$TEsorter/" if $TEsorter ne '' and $TEsorter !~ /\/$/;
 die "Error: TEsorter is not found in the TEsorter path $TEsorter!\n" unless -X "${TEsorter}TEsorter";
 # makeblastdb, blastn
-chomp ($blastplus=`which makeblastdb 2>/dev/null`) if $blastplus eq '';
+chomp ($blastplus=`command -v makeblastdb 2>/dev/null`) if $blastplus eq '';
 $blastplus =~ s/\s+$//;
 $blastplus = dirname($blastplus) unless -d $blastplus;
 $blastplus="$blastplus/" if $blastplus ne '' and $blastplus !~ /\/$/;
 die "Error: makeblastdb is not found in the BLAST+ path $blastplus!\n" unless -X "${blastplus}makeblastdb";
 die "Error: blastn is not found in the BLAST+ path $blastplus!\n" unless -X "${blastplus}blastn";
 # mdust
-chomp ($mdust=`which mdust 2>/dev/null`) if $mdust eq '';
+chomp ($mdust=`command -v mdust 2>/dev/null`) if $mdust eq '';
 $mdust =~ s/\s+$//;
 $mdust = dirname($mdust) unless -d $mdust;
 $mdust = "$mdust/" if $mdust ne '' and $mdust !~ /\/$/;
 die "Error: mdust is not found in the mdust path $mdust!\n" unless -X "${mdust}mdust";
 # trf
-chomp ($trf=`which trf 2>/dev/null`) if $trf eq '';
+chomp ($trf=`command -v trf 2>/dev/null`) if $trf eq '';
 $trf=~s/\n$//;
 `$trf 2>/dev/null`;
 die "Error: Tandem Repeat Finder is not found in the TRF path $trf!\n" if $?==32256;
 # GRF
-chomp ($GRF = `which grf-main 2>/dev/null`) if $GRF eq '';
+chomp ($GRF = `command -v grf-main 2>/dev/null`) if $GRF eq '';
 $GRF =~ s/\n$//;
 my $grfp= dirname ($GRF);
 $grfp =~ s/\n$//;

--- a/bin/LTR_FINDER_parallel/LTR_FINDER_parallel
+++ b/bin/LTR_FINDER_parallel/LTR_FINDER_parallel
@@ -82,7 +82,7 @@ if ($help) {
                  -message => "$usage\n" } );
 }
 
-$ltr_finder=`which ltr_finder 2>/dev/null` if $ltr_finder eq '';
+$ltr_finder=`command -v ltr_finder 2>/dev/null` if $ltr_finder eq '';
 $ltr_finder = "$script_path/bin/LTR_FINDER.x86_64-1.0.7/ltr_finder" if $ltr_finder eq ''; #use default ltr_finder if not ENV
 $ltr_finder=~s/ltr_finder\n?//;
 $ltr_finder="$ltr_finder/" if $ltr_finder ne '' and $ltr_finder !~ /\/$/;

--- a/development/EDTA_raw_2.1.3.pl
+++ b/development/EDTA_raw_2.1.3.pl
@@ -153,14 +153,14 @@ die "The script bed2gff.pl is not found in $bed2gff!\n" unless -s $bed2gff;
 die "The script make_bed_with_intact.pl is not found in $make_bed!\n" unless -s $make_bed;
 
 # GenomeTools
-chomp ($genometools=`which gt 2>/dev/null`) if $genometools eq '';
+chomp ($genometools=`command -v gt 2>/dev/null`) if $genometools eq '';
 $genometools =~ s/\s+$//;
 $genometools = dirname($genometools) unless -d $genometools;
 $genometools="$genometools/" if $genometools ne '' and $genometools !~ /\/$/;
 die "Error: gt is not found in the genometools path $genometools!\n" unless -X "${genometools}gt";
 # RepeatMasker
 my $rand=int(rand(1000000));
-chomp ($repeatmasker=`which RepeatMasker 2>/dev/null`) if $repeatmasker eq '';
+chomp ($repeatmasker=`command -v RepeatMasker 2>/dev/null`) if $repeatmasker eq '';
 $repeatmasker =~ s/\s+$//;
 $repeatmasker = dirname($repeatmasker) unless -d $repeatmasker;
 $repeatmasker="$repeatmasker/" if $repeatmasker ne '' and $repeatmasker !~ /\/$/;
@@ -170,37 +170,37 @@ my $RM_test=`${repeatmasker}RepeatMasker -e ncbi -q -pa 1 -no_is -norna -nolow d
 die "Error: The RMblast engine is not installed in RepeatMasker!\n" unless $RM_test=~s/done//gi;
 `rm dummy060817.fa.$rand*`;
 # LTR_retriever
-chomp ($LTR_retriever=`which LTR_retriever 2>/dev/null`) if $LTR_retriever eq '';
+chomp ($LTR_retriever=`command -v LTR_retriever 2>/dev/null`) if $LTR_retriever eq '';
 $LTR_retriever =~ s/\s+$//;
 $LTR_retriever = dirname($LTR_retriever) unless -d $LTR_retriever;
 $LTR_retriever="$LTR_retriever/" if $LTR_retriever ne '' and $LTR_retriever !~ /\/$/;
 die "Error: LTR_retriever is not found in the LTR_retriever path $LTR_retriever!\n" unless -X "${LTR_retriever}LTR_retriever";
 # TEsorter
-chomp ($TEsorter=`which TEsorter 2>/dev/null`) if $TEsorter eq '';
+chomp ($TEsorter=`command -v TEsorter 2>/dev/null`) if $TEsorter eq '';
 $TEsorter =~ s/\s+$//;
 $TEsorter = dirname($TEsorter) unless -d $TEsorter;
 $TEsorter="$TEsorter/" if $TEsorter ne '' and $TEsorter !~ /\/$/;
 die "Error: TEsorter is not found in the TEsorter path $TEsorter!\n" unless -X "${TEsorter}TEsorter";
 # makeblastdb, blastn
-chomp ($blastplus=`which makeblastdb 2>/dev/null`) if $blastplus eq '';
+chomp ($blastplus=`command -v makeblastdb 2>/dev/null`) if $blastplus eq '';
 $blastplus =~ s/\s+$//;
 $blastplus = dirname($blastplus) unless -d $blastplus;
 $blastplus="$blastplus/" if $blastplus ne '' and $blastplus !~ /\/$/;
 die "Error: makeblastdb is not found in the BLAST+ path $blastplus!\n" unless -X "${blastplus}makeblastdb";
 die "Error: blastn is not found in the BLAST+ path $blastplus!\n" unless -X "${blastplus}blastn";
 # mdust
-chomp ($mdust=`which mdust 2>/dev/null`) if $mdust eq '';
+chomp ($mdust=`command -v mdust 2>/dev/null`) if $mdust eq '';
 $mdust =~ s/\s+$//;
 $mdust = dirname($mdust) unless -d $mdust;
 $mdust = "$mdust/" if $mdust ne '' and $mdust !~ /\/$/;
 die "Error: mdust is not found in the mdust path $mdust!\n" unless -X "${mdust}mdust";
 # trf
-chomp ($trf=`which trf 2>/dev/null`) if $trf eq '';
+chomp ($trf=`command -v trf 2>/dev/null`) if $trf eq '';
 $trf=~s/\n$//;
 `$trf 2>/dev/null`;
 die "Error: Tandem Repeat Finder is not found in the TRF path $trf!\n" if $?==32256;
 # GRF
-chomp ($GRF = `which grf-main 2>/dev/null`) if $GRF eq '';
+chomp ($GRF = `command -v grf-main 2>/dev/null`) if $GRF eq '';
 $GRF =~ s/\n$//;
 `$GRF 2>/dev/null`;
 die "Error: The Generic Repeat Finder (GRF) is not found in the GRF path: $GRF\n" if $?==32256;

--- a/development/EDTA_rm.pl
+++ b/development/EDTA_rm.pl
@@ -233,20 +233,20 @@ die "The script rename_by_list.pl is not found in $rename_by_list!\n" unless -s 
 die "The script output_by_list.pl is not found in $output_by_list!\n" unless -s $output_by_list;
 
 # GenomeTools
-chomp ($genometools=`which gt 2>/dev/null`) if $genometools eq '';
+chomp ($genometools=`command -v gt 2>/dev/null`) if $genometools eq '';
 $genometools =~ s/\s+$//;
 $genometools = dirname($genometools) unless -d $genometools;
 $genometools="$genometools/" if $genometools ne '' and $genometools !~ /\/$/;
 die "Error: gt is not found in the genometools path $genometools!\n" unless -X "${genometools}gt";
 # LTR_retriever
-chomp ($LTR_retriever=`which LTR_retriever 2>/dev/null`) if $LTR_retriever eq '';
+chomp ($LTR_retriever=`command -v LTR_retriever 2>/dev/null`) if $LTR_retriever eq '';
 $LTR_retriever =~ s/\s+$//;
 $LTR_retriever = dirname($LTR_retriever) unless -d $LTR_retriever;
 $LTR_retriever="$LTR_retriever/" if $LTR_retriever ne '' and $LTR_retriever !~ /\/$/;
 die "Error: LTR_retriever is not found in the LTR_retriever path $LTR_retriever!\n" unless -X "${LTR_retriever}LTR_retriever";
 # RepeatMasker
 my $rand=int(rand(1000000));
-chomp ($repeatmasker=`which RepeatMasker 2>/dev/null`) if $repeatmasker eq '';
+chomp ($repeatmasker=`command -v RepeatMasker 2>/dev/null`) if $repeatmasker eq '';
 $repeatmasker =~ s/\s+$//;
 $repeatmasker = dirname($repeatmasker) unless -d $repeatmasker;
 $repeatmasker="$repeatmasker/" if $repeatmasker ne '' and $repeatmasker !~ /\/$/;
@@ -256,13 +256,13 @@ my $RM_test=`${repeatmasker}RepeatMasker -e ncbi -q -pa 1 -no_is -norna -nolow d
 die "Error: The RMblast engine is not installed in RepeatMasker!\n" unless $RM_test=~s/done//gi;
 `rm dummy060817.fa.$rand* 2>/dev/null`;
 # RepeatModeler
-chomp ($repeatmodeler=`which RepeatModeler 2>/dev/null`) if $repeatmodeler eq '';
+chomp ($repeatmodeler=`command -v RepeatModeler 2>/dev/null`) if $repeatmodeler eq '';
 $repeatmodeler =~ s/\s+$//;
 $repeatmodeler = dirname($repeatmodeler) unless -d $repeatmodeler;
 $repeatmodeler="$repeatmodeler/" if $repeatmodeler ne '' and $repeatmodeler !~ /\/$/;
 die "Error: RepeatModeler is not found in the RepeatModeler path $repeatmodeler!\n" unless -X "${repeatmodeler}RepeatModeler";
 # makeblastdb, blastn, blastx
-chomp ($blastplus=`which makeblastdb 2>/dev/null`) if $blastplus eq '';
+chomp ($blastplus=`command -v makeblastdb 2>/dev/null`) if $blastplus eq '';
 $blastplus =~ s/\s+$//;
 $blastplus = dirname($blastplus) unless -d $blastplus;
 $blastplus="$blastplus/" if $blastplus ne '' and $blastplus !~ /\/$/;
@@ -270,24 +270,24 @@ die "Error: makeblastdb is not found in the BLAST+ path $blastplus!\n" unless -X
 die "Error: blastn is not found in the BLAST+ path $blastplus!\n" unless -X "${blastplus}blastn";
 die "Error: blastx is not found in the BLAST+ path $blastplus!\n" unless -X "${blastplus}blastx";
 # TEsorter
-chomp ($TEsorter=`which TEsorter 2>/dev/null`) if $TEsorter eq '';
+chomp ($TEsorter=`command -v TEsorter 2>/dev/null`) if $TEsorter eq '';
 $TEsorter =~ s/\s+$//;
 $TEsorter = dirname($TEsorter) unless -d $TEsorter;
 $TEsorter="$TEsorter/" if $TEsorter ne '' and $TEsorter !~ /\/$/;
 die "Error: TEsorter is not found in the TEsorter path $TEsorter!\n" unless -X "${TEsorter}TEsorter";
 # mdust
-chomp ($mdust=`which mdust 2>/dev/null`) if $mdust eq '';
+chomp ($mdust=`command -v mdust 2>/dev/null`) if $mdust eq '';
 $mdust =~ s/\s+$//;
 $mdust = dirname($mdust) unless -d $mdust;
 $mdust = "$mdust/" if $mdust ne '' and $mdust !~ /\/$/;
 die "Error: mdust is not found in the mdust path $mdust!\n" unless -X "${mdust}mdust";
 # trf
-chomp ($trf=`which trf 2>/dev/null`) if $trf eq '';
+chomp ($trf=`command -v trf 2>/dev/null`) if $trf eq '';
 $trf=~s/\n$//;
 `$trf 2>/dev/null`;
 die "Error: Tandem Repeat Finder is not found in the TRF path $trf!\n" if $?==32256;
 # GRF
-chomp ($GRF = `which grf-main 2>/dev/null`) if $GRF eq '';
+chomp ($GRF = `command -v grf-main 2>/dev/null`) if $GRF eq '';
 $GRF =~ s/\n$//;
 `$GRF 2>/dev/null`;
 die "Error: The Generic Repeat Finder (GRF) is not found in the GRF path: $GRF\n" if $?==32256;

--- a/util/cleanup_nested.pl
+++ b/util/cleanup_nested.pl
@@ -63,7 +63,7 @@ foreach (@ARGV){
 die "\nERROR: Input sequence file is not exist!\n$usage" unless -s $IN;
 die "\nERROR: The -iter parameter receives non-integer input!\n$usage" unless $user_iter =~ /^[0-9]+$/;
 $blastplus = "" unless defined $blastplus;
-$blastplus=`which blastn 2>/dev/null` if $blastplus eq '';
+$blastplus=`command -v blastn 2>/dev/null` if $blastplus eq '';
 $blastplus=~s/blastn\n//;
 die "ERROR: blastn is not exist in the BLAST+ path $blastplus!\n" unless -X "${blastplus}blastn";
 

--- a/util/cleanup_nested_old.pl
+++ b/util/cleanup_nested_old.pl
@@ -54,7 +54,7 @@ foreach (@ARGV){
 die "\nERROR: Input sequence file is not exist!\n$usage" unless -s $IN;
 die "\nERROR: The -iter parameter receives non-integer input!\n$usage" unless $iter =~ /^[0-9]+$/;
 $blastplus = "" unless defined $blastplus;
-$blastplus=`which blastn 2>/dev/null` if $blastplus eq '';
+$blastplus=`command -v blastn 2>/dev/null` if $blastplus eq '';
 $blastplus=~s/blastn\n//;
 die "ERROR: blastn is not exist in the BLAST+ path $blastplus!\n" unless -X "${blastplus}blastn";
 

--- a/util/cleanup_tandem.pl
+++ b/util/cleanup_tandem.pl
@@ -68,7 +68,7 @@ foreach (@ARGV){
 	}
 
 # check TRF
-$trf_path=`which trf 2>/dev/null` if $trf_path eq '';
+$trf_path=`command -v trf 2>/dev/null` if $trf_path eq '';
 $trf_path=~s/\n$//;
 `$trf_path 2>/dev/null`;
 die "Error: No Tandem Repeat Finder is working on the current system.

--- a/util/evaluation.pl
+++ b/util/evaluation.pl
@@ -37,7 +37,7 @@ die $usage unless -s $genome;
 die $usage unless -s $RMout;
 
 #get blast path
-$blast=`which blastn 2>/dev/null` if $blast eq '';
+$blast=`command -v blastn 2>/dev/null` if $blast eq '';
 $blast=~s/blastn\n//;
 $blast="$blast/" if $blast ne '' and $blast !~ /\/$/;
 die "blastn is not exist in the BLAST+ path $blast!\n" unless -X "${blast}blastn";

--- a/util/filter_copy_number.pl
+++ b/util/filter_copy_number.pl
@@ -14,7 +14,7 @@ my $set_cdhit="-c 0.8 -G 0.8 -s 0.8 -aL 0.8 -aS 0.8 -M 0"; #set parameters for c
 my $cdhitpath='';
 
 #check cd-hit
-$cdhitpath=`which cd-hit-est 2>/dev/null` if $cdhitpath eq '';
+$cdhitpath=`command -v cd-hit-est 2>/dev/null` if $cdhitpath eq '';
 $cdhitpath=~s/cd-hit-est\n//;
 die "cd-hit-est is not exist in the CDHIT path $cdhitpath!\n" unless -X "${cdhitpath}cd-hit-est";
 die "\nThe fasta file is not found!\n$usage" unless -s $seq;


### PR DESCRIPTION
As per [the Unix and Linux StackExcchange: Why not use "which"? What to use then?](https://unix.stackexchange.com/questions/85249/why-not-use-which-what-to-use-then), `command -v` has been the POSIX standard way to find paths to commands since around 2008 or earlier.

Using EDTA.pl via Biocontainers on a Red Hat-family system, the container's `which` (from BusyBox) isn't compatible with the OS definition of `which`:

```shell
$ command -v which
alias which='alias | /usr/bin/which --tty-only --read-alias --show-dot --show-tilde'
```

Out of the box, the EDTA container fails on Red Hat-family systems as follows:

```shell
$ singularity exec EDTA.sif EDTA.pl --genome test.fa

#########################################################
##### Extensive de-novo TE Annotator (EDTA) v2.2.0  #####
##### Shujun Ou (shujun.ou.1@gmail.com)             #####
#########################################################


Parameters: --genome test.fa


Thu May 23 14:59:44 CDT 2024    Dependency checking:
Error: gt is not found in the genometools path ./!
```

But removing the OS-provided `which` function allows the container to work:

```shell
$ unset which
$ singularity exec EDTA.sif EDTA.pl --genome test.fa

#########################################################
##### Extensive de-novo TE Annotator (EDTA) v2.2.0  #####
##### Shujun Ou (shujun.ou.1@gmail.com)             #####
#########################################################


Parameters: --genome test.fa


Thu May 23 14:59:49 CDT 2024    Dependency checking:
                All passed!
```

Replacing all of the `which` calls in the Perl scripts with `command -v` should resolve this.