### PR TITLE
Update EDTA.pl

### DIFF
--- a/EDTA.pl
+++ b/EDTA.pl
@@ -74,7 +74,7 @@ perl EDTA.pl [options]
 				(--anno 1 required). Default: 1.
 	--exclude [File]	Exclude regions (bed format) from TE masking in the MAKER.masked
 				output. Default: undef. (--anno 1 required).
-	--force	[0|1]	(default: 0) 0: When no confident TE candidates are found, interrupt and exit
+	--force	[0|1]	(default: 0) 0: When no confident TE candidates are found, interrupt and exit.
 			             1: Use rice TEs to continue.
 	--u [float]	Neutral mutation rate to calculate the age of intact LTR elements.
 			Intact LTR age is found in this file: *EDTA_raw/LTR/*.pass.list.

--- a/EDTA.pl
+++ b/EDTA.pl
@@ -74,8 +74,8 @@ perl EDTA.pl [options]
 				(--anno 1 required). Default: 1.
 	--exclude [File]	Exclude regions (bed format) from TE masking in the MAKER.masked
 				output. Default: undef. (--anno 1 required).
-	--force	[0|1]	When no confident TE candidates are found: 0, interrupt and exit
-			(default); 1, use rice TEs to continue.
+	--force	[0|1]	(default: 0) 0: When no confident TE candidates are found, interrupt and exit
+			             1: Use rice TEs to continue.
 	--u [float]	Neutral mutation rate to calculate the age of intact LTR elements.
 			Intact LTR age is found in this file: *EDTA_raw/LTR/*.pass.list.
 			Default: 1.3e-8 (per bp per year, from rice).


### PR DESCRIPTION
Very brief suggested changes to EDTA.pl to make the --help dialogue easier to understand

This was in reference to https://github.com/oushujun/EDTA/issues/574 - the formatting of the previous help statement might lead users to think that `--force 1` was the default, when it is really `--force 0`.
